### PR TITLE
Please pull the latest code

### DIFF
--- a/src/main/java/com/techlooper/service/impl/VietnamWorksJobStatisticService.java
+++ b/src/main/java/com/techlooper/service/impl/VietnamWorksJobStatisticService.java
@@ -448,7 +448,7 @@ public class VietnamWorksJobStatisticService implements JobStatisticService {
         int limit = request.getLimitSkills() > 0 ? request.getLimitSkills() : 15;
         response.setTopDemandedSkills(skillStatistics.stream().sorted(
                 (skill1, skill2) -> (int) skill2.getCount() - (int) skill1.getCount()
-        ).limit(limit).collect(toList()));
+        ).filter(skill -> skill.getSkillName().length() <= 40).limit(limit).collect(toList()));
 
         return response;
     }

--- a/src/main/resources/template/salaryReviewReport.en.ftl
+++ b/src/main/resources/template/salaryReviewReport.en.ftl
@@ -317,7 +317,7 @@
                     </tr>
                     <tr>
                       <td align="left" width="100%" style="font-size: 16px;">
-                        See below the full details of this report which was generated on <strong style="font-size: 18px; font-weight: 500; color:#000000">${date}</strong>:
+                        See below the full details of this report which was generated on <strong style="font-size: 20px; font-weight: 500; color:#000000">${date}</strong>:
                       </td>
                     </tr>
                     <tr>

--- a/src/main/resources/template/salaryReviewReport.vi.ftl
+++ b/src/main/resources/template/salaryReviewReport.vi.ftl
@@ -317,7 +317,7 @@
                     </tr>
                     <tr>
                       <td align="left" width="100%" style="font-size: 16px;">
-                        Chi tiết báo cáo lương ngày <strong style="font-size: 18px; font-weight: 500; color:#000000">${date}</strong> như sau:
+                        Chi tiết báo cáo lương ngày <strong style="font-size: 20px; font-weight: 500; color:#000000">${date}</strong> như sau:
                       </td>
                     </tr>
                     <tr>

--- a/src/main/webapp/assets/modules/app.js
+++ b/src/main/webapp/assets/modules/app.js
@@ -192,24 +192,24 @@ techlooper.run(function (shortcutFactory, connectionFactory, loadingBoxFactory, 
     return rsLocationPathFn;
   }
 
-  //var doTranslate = function() {
-  //  $translate(["newGradLevel", "experienced", "manager", "timeline", "numberOfJobs", "jobs", "isRequired", "exItSoftware", "ex149",
-  //    "salaryRangeJob", "jobNumber", "salaryRangeInJob", "jobNumberLabel", "allLevel", "newGradLevel", "exHoChiMinh", "exManager",
-  //    "experienced", "manager", "maximum5", "maximum3", "hasExist", "directorAndAbove", "requiredThisField",
-  //    "genderMale", "genderFemale", "exMale", "exYob", 'exDay', 'day', 'week', 'month', "maximum50"]).then(function (translate) {
-  //    $rootScope.translate = translate;
-  //  });
-  //}
+  var doTranslate = function() {
+    $translate(["newGradLevel", "experienced", "manager", "timeline", "numberOfJobs", "jobs", "isRequired", "exItSoftware", "ex149",
+      "salaryRangeJob", "jobNumber", "salaryRangeInJob", "jobNumberLabel", "allLevel", "newGradLevel", "exHoChiMinh", "exManager",
+      "experienced", "manager", "maximum5", "maximum3", "hasExist", "directorAndAbove", "requiredThisField",
+      "genderMale", "genderFemale", "exMale", "exYob", 'exDay', 'day', 'week', 'month', "maximum50"]).then(function (translate) {
+      $rootScope.translate = translate;
+    });
+  }
 
   var campaign = $location.search();
   var langKey = (campaign && campaign.lang);
   langKey !== $translate.use() && ($translate.use(langKey));
   $rootScope.$on('$translateChangeSuccess', function () {
     langKey !== $translate.use() && ($translate.use(langKey));
-    //doTranslate();
+    doTranslate();
   });
 
-  //doTranslate();
+  doTranslate();
 
   $rootScope.jsonValue = jsonValue;
 

--- a/src/main/webapp/assets/modules/contest/contest.tem.html
+++ b/src/main/webapp/assets/modules/contest/contest.tem.html
@@ -1,7 +1,7 @@
 <nav class="navbar">
   <div class="logo-block text-center">
     <div class="logo" id="logo">
-      <h1><a href="#/salary-review"> <img src="images/logo.svg" alt="Career Analytics. Awesome!"></a></h1>
+      <h1><a href="#/"> <img src="images/logo.svg" alt="Career Analytics. Awesome!"></a></h1>
     </div>
     <div class="vnw-logo">
       <a href="http://www.vietnamworks.com/" target="_blank"><img src="images/vnw-logo.svg" alt="Career Analytics. Awesome!"></a>

--- a/src/main/webapp/assets/modules/get-promoted/get-promoted.tem.html
+++ b/src/main/webapp/assets/modules/get-promoted/get-promoted.tem.html
@@ -1,7 +1,7 @@
 <nav class="navbar">
   <div class="logo-block text-center">
     <div class="logo" id="logo">
-      <h1><a href="#/salary-review"> <img src="images/logo.svg" alt="Career Analytics. Awesome!"></a></h1>
+      <h1><a href="#/"> <img src="images/logo.svg" alt="Career Analytics. Awesome!"></a></h1>
     </div>
     <div class="vnw-logo">
       <a href="http://www.vietnamworks.com/" target="_blank"><img src="images/vnw-logo.svg" alt="Career Analytics. Awesome!"></a>


### PR DESCRIPTION
1. Exclude skills greater than 40 characters from the Top Demanded skills 

2. Emphasize Date info for Salary report email 

3. Button "See Latest Skills Trend" looks "too Square" not good in Get promoted email 

4. Do not open autocompletion for Expected Job Title in GetPromoted page by clicking on "See Latest Skills Trend" from Get promoted email 

5. Clicking on techlooper logo of Contest and GetPromoted page, should lead to homepage, not SalaryReview page